### PR TITLE
Update fzf repo

### DIFF
--- a/config/generic.yaml
+++ b/config/generic.yaml
@@ -66,7 +66,7 @@
 - repo: fission
   org: fission
 
-- repo: fzf-bin
+- repo: fzf
   org: junegunn
   name: fzf
 


### PR DESCRIPTION
https://github.com/junegunn/fzf-bin is deprecated, all releases in main repo are now include binaries https://github.com/junegunn/fzf/releases