### PR TITLE
feat: Add minectl to bot config

### DIFF
--- a/config/generic.yaml
+++ b/config/generic.yaml
@@ -79,6 +79,9 @@
 - repo: stern
   org: wercker
 
+- repo: minectl
+  org: dirien
+
 - repo: helm
   org: helm
 


### PR DESCRIPTION
Please add minectl to bot config. 

Fish-food lua is already there-> https://github.com/fishworks/fish-food/blob/main/Food/minectl.lua

Signed-off-by: Engin Diri <engin.diri@mail.schwarz>