### PR TITLE
Add jreleaser package

### DIFF
--- a/config/generic.yaml
+++ b/config/generic.yaml
@@ -263,6 +263,10 @@
 - repo: yq
   org: mikefarah
 
+- repo: jreleaser
+  org: jreleaser
+  name: jreleaser-standalone
+  
 # Release not following semantic versioning
 # - repo: linkerd2
 #   org: linkerd


### PR DESCRIPTION
JReleaser follows semantic versioning and posts multiple binaries.

Binaries intended for consumption via gofish are

```
jreleaser-standalone-${version}-linux-aarch64.zip
jreleaser-standalone-${version}-linux-x86_64.zip
jreleaser-standalone-${version}-osx-aarch64.zip
jreleaser-standalone-${version}-osx-x86_64.zip
jreleaser-standalone-${version}-windows-aarch64.zip
jreleaser-standalone-${version}-windows-x86_64.zip
```

Should additional mappings be made for the bot to find the correct set of binaries?